### PR TITLE
adjust build.sh for macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+os_ver=${1-$(uname -s)}
 list=$(ls -r ./*.md)
 for file in $list ; do
   date=$(date -r ${file} +%D)
@@ -10,7 +11,13 @@ for file in $list ; do
   cat head.htm_ > ${target}
   cmark --unsafe ${file}.md >> ${target}
   cat foot.htm_ >> ${target}
-  sed -i 's|DATE|'$date'|g' ${target}
+  if [[ "$os_ver" == "Darwin" ]]; then
+	  echo "macOS detected"
+	  sed -i '' -e 's#DATE#'$date'#g' ${target}
+  else
+	  echo "not macOS"
+	  sed -i 's|DATE|'$date'|g' ${target}
+  fi
 done
 
 sed -i -e '/GRID/r grid.htm_' -e '/NORNS/r norns.htm_' -e 'x;$G' index.html


### PR DESCRIPTION
differentiates the `sed` arguments for macOS to replace `DATE` placeholders.
@tehn, lmk if this breaks for you, though!!