### PR TITLE
b-stock specifics

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   <li><a href="https://monome.org/docs/grid">documentation</a></li>
 </ul>
 <p>$650 &mdash; b-stock available 02/18 1pm EST (normally $700). will ship within two weeks.</p>
-<p>b-stock is functionally perfect but may have some minor aesthetic defects.</p>
+<p>b-stock is functionally perfect but metal enclosure may have some minor aesthetic defects.</p>
 <div id='product-component-1657674560727'></div>
 <script type="text/javascript">
 /*<![CDATA[*/
@@ -287,7 +287,7 @@
 <p>monome is supported by a global community of curious, helpful, and creative people. <a href="https://dndrks.com">dan derks</a> is on the team. all based at <a href="https://luckdragon.space">luck dragon</a>.</p>
 <p>we began in 2005. we continue.</p>
 <hr/>
-<p>monome &mdash; updated 02/18/23</p>
+<p>monome &mdash; updated 03/05/23</p>
 
 </div>
 </body>

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@
   <li><a href="https://monome.org/docs/grid">documentation</a></li>
 </ul>
 <p>$650 &mdash; b-stock available 02/18 1pm EST (normally $700). will ship within two weeks.</p>
-<p>b-stock is functionally perfect but may have some minor aesthetic defects.</p>
+<p>b-stock is functionally perfect but metal enclosure may have some minor aesthetic defects.</p>
 
 <!--GRID-->
 


### PR DESCRIPTION
we've gotten a few support tickets where folks want to verify that the b-stock aesthetic defects don't include the LEDs in any way, so thought this change might help